### PR TITLE
[K8S] KyuubiConf.getKubernetesConf should set namespace even if the Kubernetes context is empty

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -154,9 +154,9 @@ case class KyuubiConf(loadSysDefault: Boolean = true) extends Logging {
         conf.set(key, value)
       }
       conf.set(KUBERNETES_CONTEXT, c)
-      namespace.foreach(ns => conf.set(KUBERNETES_NAMESPACE, ns))
       conf
     }
+    namespace.foreach(ns => conf.set(KUBERNETES_NAMESPACE, ns))
     conf
   }
 


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

When submit Spark engine to Kubernetes environment, `org.apache.kyuubi.engine.KubernetesApplicationOperation#getApplicationInfoByTag` will use Kubernetes client to get driver pod info, if we do not set `spark.kubernetes.context`configuration in Spark environment, `org.apache.kyuubi.config.KyuubiConf#getKubernetesConf` will construct a client with **default** namespace, this will cause privilege problem if Kyuubi running with a partial rolebinding service account:

```log
2024-03-13 18:13:47.409 ERROR KyuubiSessionManager-exec-pool: Thread-56 org.apache.kyuubi.engine.KubernetesApplicationOperation: Failed to get application by label: kyuubi-unique-tag=b61924ef-a93e-46a3-94be-0de70be5fb5e, due to Failure executing: GET at: https://******:6443/api/v1/namespaces/default/pods?labelSelector=kyuubi-unique-tag&resourceVersion=0. Message: pods is forbidden: User "system:serviceaccount:kyuubi:kyuubi" cannot list resource "pods" in API group "" in the namespace "default". Received status: Status(apiVersion=v1, code=403, details=StatusDetails(causes=[], group=null, kind=pods, name=null, retryAfterSeconds=null, uid=null, additionalProperties={}), kind=Status, message=pods is forbidden: User "system:serviceaccount:kyuubi:kyuubi" cannot list resource "pods" in API group "" in the namespace "default", metadata=ListMeta(_continue=null, remainingItemCount=null, resourceVersion=null, selfLink=null, additionalProperties={}), reason=Forbidden, status=Failure, additionalProperties={}).
```

This will appear as engine startup failure, but in fact the engine is started successfully.

## Describe Your Solution 🔧

`KyuubiConf.getKubernetesConf` method should set namespace even if the Kubernetes context is empty, please see the commit.

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests


---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
